### PR TITLE
Switch production base image to runtime-slim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  * Added V2 implementation from LiGet
  * Added compatibility mode with LiGet to keep the same endpoints
  * V2 includes dependencies in package query results
+ * Switch production base image to slim stretch
 
 ### 0.1.0 (2018-Nov-09)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.402-sdk-stretch
+FROM microsoft/dotnet:2.1.4-aspnetcore-runtime-stretch-slim
 EXPOSE 9090
 
 RUN apt-get update && apt-get install -y sudo &&\


### PR DESCRIPTION
The sdk image was used by mistake.