### PR TITLE
fix cases when external mounts are owned by root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
 
 RUN mkdir -p /home/baget /home/baget/.nuget/NuGet &&\
-    mkdir -p /var/baget/packages /var/baget/db &&\
+    mkdir -p /var/baget/packages /var/baget/db /var/baget/cache &&\
     groupadd -g 1000 baget &&\
     useradd -d /home/baget -s /bin/bash -u 1000 -g baget baget &&\
     chown -R baget:baget /home/baget /var/baget/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV ASPNETCORE_ENVIRONMENT=Production \
     Mirror__PackagesPath="/var/baget/cache" \
     Search__Type=Database
 
+
 COPY /src/BaGet/bin/Release/netcoreapp2.1/publish/ /app
 
 ADD docker-scripts/run.sh /app/run.sh

--- a/docker-scripts/run.sh
+++ b/docker-scripts/run.sh
@@ -56,6 +56,7 @@ chown $NEWUID:$NEWGID -R /home/baget
 # Start server
 ###########################################################################
 
+cd /app
 if [ ! -z ${BAGET_IMPORT_ON_BOOT+x} ]; then
   if [[ $NEWGID != 0 ]]; then
     sudo -u baget -E -H dotnet /app/BaGet.dll import --path ${BAGET_IMPORT_ON_BOOT}
@@ -65,7 +66,6 @@ if [ ! -z ${BAGET_IMPORT_ON_BOOT+x} ]; then
   fi
 fi
 
-cd /app
 if [[ $NEWGID != 0 ]]; then
   exec sudo -u baget -E -H dotnet /app/BaGet.dll
 else

--- a/docker-scripts/run.sh
+++ b/docker-scripts/run.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+DIRECTORY="/var/baget/packages"
+OWNER_USERNAME="baget"
+OWNER_GROUPNAME="baget"
+
+# First deployment bootstrap, we might want to change permissions of mounted volumes
+if [ ! -f /var/baget/db/sqlite.db ]; then
+  echo "Database does not exist yet. Setting up directory access"
+  mkdir -p /var/baget/packages /var/baget/db /var/baget/cache
+  chown -R baget:baget /var/baget/
+fi
+
 ###########################################################################
 # Used as fix-uid-gid solution in docker, almost copied from:
 # https://github.com/tomzo/docker-uid-gid-fix/blob/master/fix-uid-gid.sh
@@ -8,9 +19,6 @@ set -e
 
 # This is the directory we expect to be mounted as docker volume.
 # From that directory we know uid and gid.
-DIRECTORY="/var/baget/packages"
-OWNER_USERNAME="baget"
-OWNER_GROUPNAME="baget"
 
 if [ ! -d "$DIRECTORY" ]; then
   echo "$DIRECTORY does not exist, expected to be mounted as docker volume"
@@ -49,7 +57,12 @@ chown $NEWUID:$NEWGID -R /home/baget
 ###########################################################################
 
 if [ ! -z ${BAGET_IMPORT_ON_BOOT+x} ]; then
-  sudo -u baget -E -H dotnet /app/BaGet.dll import --path ${BAGET_IMPORT_ON_BOOT}
+  if [[ $NEWGID != 0 ]]; then
+    sudo -u baget -E -H dotnet /app/BaGet.dll import --path ${BAGET_IMPORT_ON_BOOT}
+  else
+    echo "WARNING: running baget as root"
+    dotnet /app/BaGet.dll import --path ${BAGET_IMPORT_ON_BOOT}
+  fi
 fi
 
 cd /app

--- a/src/BaGet.Core/Services/PackageImporter.cs
+++ b/src/BaGet.Core/Services/PackageImporter.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace BaGet.Core.Services
@@ -14,15 +16,54 @@ namespace BaGet.Core.Services
 
         public async Task ImportAsync(string pkgDirectory, TextWriter output)
         {
-            string[] files = Directory.GetFiles(pkgDirectory, "*.nupkg", SearchOption.AllDirectories);
+            var files = GetDirectoryFiles(pkgDirectory, "*.nupkg", SearchOption.AllDirectories, output);
             foreach (string file in files)
             {
                 output.Write("Importing package {0} ", file);
-                using(var uploadStream = File.OpenRead(file)) {
+                using (var uploadStream = File.OpenRead(file))
+                {
                     var result = await _indexingService.IndexAsync(uploadStream);
                     output.WriteLine(result);
                 }
-            }            
+            }
+        }
+
+        /// <summary>
+        /// A safe way to get all the files in a directory and sub directory without crashing on UnauthorizedException or PathTooLongException
+        /// </summary>
+        /// <param name="rootPath">Starting directory</param>
+        /// <param name="patternMatch">Filename pattern match</param>
+        /// <param name="searchOption">Search subdirectories or only top level directory for files</param>
+        /// <returns>List of files</returns>
+        public static IEnumerable<string> GetDirectoryFiles(string rootPath, string patternMatch, SearchOption searchOption, TextWriter output)
+        {
+            var foundFiles = Enumerable.Empty<string>();
+
+            if (searchOption == SearchOption.AllDirectories)
+            {
+                try
+                {
+                    IEnumerable<string> subDirs = Directory.EnumerateDirectories(rootPath);
+                    foreach (string dir in subDirs)
+                    {
+                        foundFiles = foundFiles.Concat(GetDirectoryFiles(dir, patternMatch, searchOption, output)); // Add files in subdirectories recursively to the list
+                    }
+                }
+                catch (UnauthorizedAccessException) { 
+                    output.WriteLine("Skipping {0} because of insufficient permissions", rootPath);
+                }
+                catch (PathTooLongException) {}
+            }
+
+            try
+            {
+                foundFiles = foundFiles.Concat(Directory.EnumerateFiles(rootPath, patternMatch)); // Add files from the current directory
+            }
+            catch (UnauthorizedAccessException) { 
+                output.WriteLine("Skipping {0} because of insufficient permissions", rootPath);
+            }
+
+            return foundFiles;
         }
     }
 }

--- a/src/BaGet/Extensions/IHostBuilderExtensions.cs
+++ b/src/BaGet/Extensions/IHostBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Gelf.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -29,12 +31,16 @@ namespace BaGet.Extensions
         public static IHostBuilder ConfigureBaGetLogging(this IHostBuilder builder)
         {
             return builder
+                .ConfigureServices((hostBuilder, services) => {
+                    services.Configure<GelfLoggerOptions>(hostBuilder.Configuration.GetSection("Graylog"));
+                })
                 .ConfigureLogging((context, logging) =>
-                    {
-                        logging.AddConfiguration(context.Configuration.GetSection("Logging"));
-                        logging.AddConsole();
-                        logging.AddDebug();
-                    });
+                {
+                    logging.AddConfiguration(context.Configuration.GetSection("Logging"));
+                    logging.AddConsole();
+                    logging.AddDebug();                        
+                    logging.AddGelf();
+                });
         }
 
         public static IHostBuilder ConfigureBaGetServices(this IHostBuilder builder)

--- a/src/BaGet/Extensions/IHostBuilderExtensions.cs
+++ b/src/BaGet/Extensions/IHostBuilderExtensions.cs
@@ -13,12 +13,12 @@ namespace BaGet.Extensions
         public static IHostBuilder ConfigureBaGetConfiguration(this IHostBuilder builder, string[] args)
         {
             return builder.ConfigureAppConfiguration((context, config) =>
-            {
-                config.AddEnvironmentVariables();
-
+            {               
                 config
                     .SetBasePath(Environment.CurrentDirectory)
                     .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+
+                config.AddEnvironmentVariables();
 
                 if (args != null)
                 {


### PR DESCRIPTION
### What does this PR do?

Fixes cases when baget is deployed with volumes mounted and owned by root.
It will change ownership of all baget directories, but only if database is not created yet.
Changes the order of configuration overloading, so that we can use environment variables to override defaults.

